### PR TITLE
Изменение системы переодических спавнеров.

### DIFF
--- a/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
@@ -1,3 +1,4 @@
+// Corvax-Change-Start
 using System.Threading;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -10,5 +11,6 @@ public sealed partial class TimedSpawnerComponent : Component
     [DataField] public int IntervalSeconds = 60;
     [DataField] public int MinimumEntitiesSpawned = 1;
     [DataField] public int MaximumEntitiesSpawned = 1;
-    public CancellationTokenSource? TokenSource;
+    public float TimeElapsed;
 }
+// Corvax-Change-End

--- a/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/TimedSpawnerComponent.cs
@@ -1,54 +1,14 @@
-﻿using System.Threading;
+using System.Threading;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
-namespace Content.Server.Spawners.Components;
-
-/// <summary>
-/// Spawns entities at a set interval.
-/// Can configure the set of entities, spawn timing, spawn chance,
-/// and min/max number of entities to spawn.
-/// </summary>
 [RegisterComponent, EntityCategory("Spawner")]
-public sealed partial class TimedSpawnerComponent : Component, ISerializationHooks
+public sealed partial class TimedSpawnerComponent : Component
 {
-    /// <summary>
-    /// List of entities that can be spawned by this component. One will be randomly
-    /// chosen for each entity spawned. When multiple entities are spawned at once,
-    /// each will be randomly chosen separately.
-    /// </summary>
-    [DataField]
-    public List<EntProtoId> Prototypes = [];
-
-    /// <summary>
-    /// Chance of an entity being spawned at the end of each interval.
-    /// </summary>
-    [DataField]
-    public float Chance = 1.0f;
-
-    /// <summary>
-    /// Length of the interval between spawn attempts.
-    /// </summary>
-    [DataField]
-    public int IntervalSeconds = 60;
-
-    /// <summary>
-    /// The minimum number of entities that can be spawned when an interval elapses.
-    /// </summary>
-    [DataField]
-    public int MinimumEntitiesSpawned = 1;
-
-    /// <summary>
-    /// The maximum number of entities that can be spawned when an interval elapses.
-    /// </summary>
-    [DataField]
-    public int MaximumEntitiesSpawned = 1;
-
+    [DataField] public List<EntProtoId> Prototypes = [];
+    [DataField] public float Chance = 1.0f;
+    [DataField] public int IntervalSeconds = 60;
+    [DataField] public int MinimumEntitiesSpawned = 1;
+    [DataField] public int MaximumEntitiesSpawned = 1;
     public CancellationTokenSource? TokenSource;
-
-    void ISerializationHooks.AfterDeserialization()
-    {
-        if (MinimumEntitiesSpawned > MaximumEntitiesSpawned)
-            throw new ArgumentException("MaximumEntitiesSpawned can't be lower than MinimumEntitiesSpawned!");
-    }
 }

--- a/Content.Server/Spawners/EntitySystems/SpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/SpawnerSystem.cs
@@ -1,44 +1,96 @@
 using System.Threading;
 using Content.Server.Spawners.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.SSDIndicator;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Spawners.EntitySystems;
 
 public sealed class SpawnerSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+    private const float SpawnBlockRange = 15f;
+    private EntityQuery<MetaDataComponent> _metaQuery;
+    private EntityQuery<TransformComponent> _xformQuery;
 
     public override void Initialize()
     {
         base.Initialize();
+        _metaQuery = GetEntityQuery<MetaDataComponent>();
+        _xformQuery = GetEntityQuery<TransformComponent>();
         SubscribeLocalEvent<TimedSpawnerComponent, ComponentInit>(OnSpawnerInit);
         SubscribeLocalEvent<TimedSpawnerComponent, ComponentShutdown>(OnTimedSpawnerShutdown);
     }
 
     private void OnSpawnerInit(EntityUid uid, TimedSpawnerComponent component, ComponentInit args)
     {
-        component.TokenSource?.Cancel();
         component.TokenSource = new CancellationTokenSource();
-        uid.SpawnRepeatingTimer(TimeSpan.FromSeconds(component.IntervalSeconds), () => OnTimerFired(uid, component), component.TokenSource.Token);
+        uid.SpawnRepeatingTimer(
+            TimeSpan.FromSeconds(component.IntervalSeconds),
+            () => OnTimerFired(uid, component),
+            component.TokenSource.Token
+        );
     }
 
     private void OnTimerFired(EntityUid uid, TimedSpawnerComponent component)
     {
+        if (ShouldBlockSpawn(uid, component))
+            return;
+
         if (!_random.Prob(component.Chance))
             return;
 
-        var number = _random.Next(component.MinimumEntitiesSpawned, component.MaximumEntitiesSpawned);
-        var coordinates = Transform(uid).Coordinates;
+        var xform = _xformQuery.GetComponent(uid);
+        var coordinates = xform.Coordinates;
 
-        for (var i = 0; i < number; i++)
+        for (var i = 0; i < _random.Next(component.MinimumEntitiesSpawned, component.MaximumEntitiesSpawned); i++)
         {
             var entity = _random.Pick(component.Prototypes);
             SpawnAtPosition(entity, coordinates);
         }
     }
 
+    private bool ShouldBlockSpawn(EntityUid uid, TimedSpawnerComponent component)
+    {
+        if (!_xformQuery.TryGetComponent(uid, out var xform) || xform.MapUid == null)
+            return true;
+
+        // Проверка активных игроков
+        foreach (var entity in _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(xform.MapPosition, SpawnBlockRange))
+        {
+            if (!Exists(entity.Owner)) continue; // Важная проверка
+            if (entity.Owner == uid) continue;
+
+            if (TryComp<SSDIndicatorComponent>(entity.Owner, out var ssd) && ssd.IsSSD)
+                continue;
+
+            return true;
+        }
+
+        // Проверка существующих мобов с защитой
+        foreach (var entity in _lookup.GetEntitiesInRange(xform.MapPosition, SpawnBlockRange))
+        {
+            if (!Exists(entity)) continue;
+            if (entity == uid) continue;
+
+            if (!_metaQuery.TryGetComponent(entity, out var meta) ||
+                meta.EntityPrototype?.ID is not { } prototypeId)
+                continue;
+
+            if (component.Prototypes.Contains(prototypeId))
+                return true;
+        }
+
+        return false;
+    }
+
     private void OnTimedSpawnerShutdown(EntityUid uid, TimedSpawnerComponent component, ComponentShutdown args)
     {
         component.TokenSource?.Cancel();
+        component.TokenSource = null;
     }
 }


### PR DESCRIPTION
# DESCRIPTION
Данный ПР меняет механику периодического спавна мобов. Он добавляет проверки в радиусе 15 тайлов на кукол, таких же мобов со спавнера. АФК игроки не мешают спавну. Теперь карты будут ощущаться более опасными и "живыми".
Писала ПР поздней ночью, хоть и тестила внутри игры. Буду рада вычитке. 

# Key features:

- Проверка близости для активных игроков (не в AFK) и таких же существующих мобов

- Игроки в SSD/AFK режиме не блокируют спавн

- Настраиваемые параметры через YAML: интервалы, шансы, количество. Ничего в YAML не было изменено

- Защита от ошибок при работе с удалёнными сущностями

- Автоматическое управление таймерами с использованием токенов отмены

</p> </details><details open><summary><h1>Changelog</h1></summary>
:cl:

balance: Мобы больше не появляются рядом с активными игроками или группами мобов (никакого десантирования трех когтей смерти вам на лицо)

tweak: Игроки в SSD/AFK не влияют на логику спавна

</details>