### PR TITLE
Update loadouts_ranger.yml

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -71,7 +71,7 @@
   items:
     - ClothingMaskGasCombat
 
-#MARK: Corvax-Add
+#Corvax-Add Start
 
 - type: loadout
   id: LoadoutNCRRangerCoat
@@ -86,7 +86,7 @@
     - N14ClothingOuterRangerCoat
 
 - type: loadout
-  id: LoadoutNCRuniformMaskDesertR
+  id: LoadoutNCRClothingMaskGasRangerDesert1
   category: Roles
   cost: 4
   exclusive: true
@@ -98,7 +98,7 @@
     - ClothingMaskGasRangerDesert
 
 - type: loadout
-  id: LoadoutNCRuniformMaskOldR
+  id: LoadoutNCRClothingMaskGasRangerOld1
   category: Roles
   cost: 4
   exclusive: true
@@ -110,7 +110,7 @@
     - ClothingMaskGasRangerOld
 
 - type: loadout
-  id: LoadoutNCRuniformMaskPriceR
+  id: LoadoutNCRClothingMaskGasRangerPrice1
   category: Roles
   cost: 4
   exclusive: true
@@ -122,7 +122,7 @@
     - ClothingMaskGasRangerPrice
 
 - type: loadout
-  id: LoadoutNCRuniformMaskEliteR
+  id: LoadoutNCRClothingMaskGasRangerElite1
   category: Roles
   cost: 4
   exclusive: true
@@ -134,7 +134,7 @@
     - ClothingMaskGasRangerElite
 
 - type: loadout
-  id: LoadoutNCRuniformMaskModifR
+  id: LoadoutNCRClothingMaskGasRangerModif1
   category: Roles
   cost: 4
   exclusive: true
@@ -146,7 +146,7 @@
     - ClothingMaskGasRangerModif
 
 - type: loadout
-  id: LoadoutNCRuniformMaskWeatheredR
+  id: LoadoutNCRClothingMaskGasRangerWeathered
   category: Roles
   cost: 1
   exclusive: true
@@ -158,7 +158,7 @@
     - ClothingMaskGasRangerWeathered
 
 - type: loadout
-  id: LoadoutNCRDesertHelmetR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetDesert1
   category: Roles
   cost: 4
   exclusive: true
@@ -170,7 +170,7 @@
     - N14ClothingHeadHatRangerHelmetDesert
 
 - type: loadout
-  id: LoadoutNCROldHelmetR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetOld
   category: Roles
   cost: 4
   exclusive: true
@@ -182,7 +182,7 @@
     - N14ClothingHeadHatRangerHelmetOld
 
 - type: loadout
-  id: LoadoutNCRPriceHelmetR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetPrice1
   category: Roles
   cost: 4
   exclusive: true
@@ -194,7 +194,7 @@
     - N14ClothingHeadHatRangerHelmetPrice
 
 - type: loadout
-  id: LoadoutNCRFoxHelmetR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetFox1
   category: Roles
   cost: 4
   exclusive: true
@@ -206,7 +206,7 @@
     - N14ClothingHeadHatRangerHelmetFox
 
 - type: loadout
-  id: LoadoutNCRModifHelmetR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetModif1
   category: Roles
   cost: 4
   exclusive: true
@@ -218,7 +218,7 @@
     - N14ClothingHeadHatRangerHelmetModif
 
 - type: loadout
-  id: LoadoutNCRNeckCloakRanger
+  id: LoadoutNCRN14ClothingNeckCloakRanger
   category: Roles
   cost: 1
   exclusive: true
@@ -228,6 +228,8 @@
         - NCRRanger
   items:
     - N14ClothingNeckCloakRanger
+
+# Corvax-Add End
 
 
 # MARK: Ranger + Vet
@@ -363,10 +365,10 @@
   items:
     - N14MedkitCombatFilled
 
-# MARK: Corvax-Add
+# Corvax-Add Start
 
 - type: loadout
-  id: LoadoutNCRuniformRed
+  id: LoadoutNCRN14ClothingUniformRangerVeteranRed
   category: Roles
   cost: 1
   exclusive: true
@@ -379,7 +381,7 @@
     - N14ClothingUniformRangerVeteranRed
 
 - type: loadout
-  id: LoadoutNCRuniformVeteran
+  id: LoadoutNCRN14ClothingUniformRangerVeteran
   category: Roles
   cost: 1
   exclusive: true
@@ -392,7 +394,7 @@
     - N14ClothingUniformRangerVeteran
 
 - type: loadout
-  id: LoadoutNCRuniformBlack
+  id: LoadoutNCRN14ClothingUniformRangerVeteranBlack
   category: Roles
   cost: 1
   exclusive: true
@@ -405,7 +407,7 @@
     - N14ClothingUniformRangerVeteranBlack
 
 - type: loadout
-  id: LoadoutNCRuniformBlue
+  id: LoadoutNCRN14ClothingUniformRangerBlue
   category: Roles
   cost: 1
   exclusive: true
@@ -418,7 +420,7 @@
     - N14ClothingUniformRangerBlue
 
 - type: loadout
-  id: LoadoutNCRuniformModif
+  id: LoadoutNCRN14ClothingUniformRangerModif
   category: Roles
   cost: 1
   exclusive: true
@@ -442,6 +444,8 @@
         - NCRRangerVeteran
   items:
     - ClothingNeckOldMantle
+
+# Corvax-Add End
 
 # MARK: Ranger Vet
 
@@ -511,10 +515,10 @@
   items:
     - N14ClothingHeadHatRangerHelmetEliteOld
 
-# MARK: Corvax-Add
+# Corvax-Add Start
 
 - type: loadout
-  id: LoadoutNCRuniformMaskEliteVR
+  id: LoadoutNCRClothingMaskGasRangerElite2
   category: Roles
   cost: 2
   exclusive: true
@@ -529,7 +533,7 @@
     - ClothingMaskGasRangerElite
 
 - type: loadout
-  id: LoadoutNCRuniformMaskPriceVR
+  id: LoadoutNCRClothingMaskGasRangerPrice2
   category: Roles
   cost: 2
   exclusive: true
@@ -541,7 +545,7 @@
     - ClothingMaskGasRangerPrice
 
 - type: loadout
-  id: LoadoutNCRuniformMaskModifVR
+  id: LoadoutNCRClothingMaskGasRangerModif2
   category: Roles
   cost: 2
   exclusive: true
@@ -553,7 +557,7 @@
     - ClothingMaskGasRangerModif
 
 - type: loadout
-  id: LoadoutNCRuniformHelmetFoxVR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetFox2
   category: Roles
   cost: 2
   exclusive: true
@@ -565,7 +569,7 @@
     - N14ClothingHeadHatRangerHelmetFox
 
 - type: loadout
-  id: LoadoutNCRuniformHelmetPriceVR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetPrice2
   category: Roles
   cost: 2
   exclusive: true
@@ -577,7 +581,7 @@
     - N14ClothingHeadHatRangerHelmetPrice
 
 - type: loadout
-  id: LoadoutNCRuniformHelmetModifVR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmetModif2
   category: Roles
   cost: 2
   exclusive: true
@@ -589,7 +593,7 @@
     - N14ClothingHeadHatRangerHelmetModif
 
 - type: loadout
-  id: LoadoutNCRuniformHelmetVR
+  id: LoadoutNCRN14ClothingHeadHatRangerHelmet2
   category: Roles
   cost: 2
   exclusive: true
@@ -601,7 +605,7 @@
     - N14ClothingHeadHatRangerHelmet
 
 - type: loadout
-  id: LoadoutNCRuniformWeathered
+  id: LoadoutNCRN14ClothingOuterRangerWeathered
   category: Roles
   cost: 2
   exclusive: true
@@ -613,7 +617,7 @@
     - N14ClothingOuterRangerWeathered
 
 - type: loadout
-  id: LoadoutNCRuniformFox
+  id: LoadoutNCRN14ClothingOuterRangerFox
   category: Roles
   cost: 2
   exclusive: true
@@ -625,7 +629,7 @@
     - N14ClothingOuterRangerFox
 
 - type: loadout
-  id: LoadoutNCRuniformPrice
+  id: LoadoutNCRN14ClothingOuterRangerPrice
   category: Roles
   cost: 2
   exclusive: true
@@ -647,3 +651,5 @@
         - NCRRangerVeteran
   items:
     - N14ClothingNeckCloakRangerPoncho
+
+# Corvax-Add End

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -71,6 +71,165 @@
   items:
     - ClothingMaskGasCombat
 
+#MARK: Corvax-Add
+
+- type: loadout
+  id: LoadoutNCRRangerCoat
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingOuterRangerCoat
+
+- type: loadout
+  id: LoadoutNCRuniformMaskDesertR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerDesert
+
+- type: loadout
+  id: LoadoutNCRuniformMaskOldR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerOld
+
+- type: loadout
+  id: LoadoutNCRuniformMaskPriceR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerPrice
+
+- type: loadout
+  id: LoadoutNCRuniformMaskEliteR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerElite
+
+- type: loadout
+  id: LoadoutNCRuniformMaskModifR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerModif
+
+- type: loadout
+  id: LoadoutNCRuniformMaskWeatheredR
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - ClothingMaskGasRangerWeathered
+
+- type: loadout
+  id: LoadoutNCRDesertHelmetR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmetDesert
+
+- type: loadout
+  id: LoadoutNCROldHelmetR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmetOld
+
+- type: loadout
+  id: LoadoutNCRPriceHelmetR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmetPrice
+
+- type: loadout
+  id: LoadoutNCRFoxHelmetR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmetFox
+
+- type: loadout
+  id: LoadoutNCRModifHelmetR
+  category: Roles
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingHeadHatRangerHelmetModif
+
+- type: loadout
+  id: LoadoutNCRNeckCloakRanger
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+  items:
+    - N14ClothingNeckCloakRanger
+
+
 # MARK: Ranger + Vet
 
 - type: loadout
@@ -98,19 +257,6 @@
         - NCRRangerVeteran
   items:
     - N14ClothingHeadHatNCRBeretRecon
-
-- type: loadout # Corvax-Change 
-  id: LoadoutNCRhatBeretRanger
-  category: Roles
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - NCRRanger
-        - NCRRangerVeteran
-  items:
-    - N14ClothingHeadHatArmyBeretRanger
 
 - type: loadout
   id: LoadoutNCRmaskDesert
@@ -217,43 +363,7 @@
   items:
     - N14MedkitCombatFilled
 
-# MARK: Ranger Vet
-
-- type: loadout
-  id: LoadoutNCRuniformModif
-  category: Roles
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - NCRRangerVeteran
-  items:
-    - N14ClothingUniformRangerModif
-
-- type: loadout
-  id: LoadoutNCRuniformBlue
-  category: Roles
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - NCRRangerVeteran
-  items:
-    - N14ClothingUniformRangerBlue
-
-- type: loadout
-  id: LoadoutNCRuniformBlack
-  category: Roles
-  cost: 1
-  exclusive: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - NCRRangerVeteran
-  items:
-    - N14ClothingUniformRangerVeteranBlack
+# MARK: Corvax-Add
 
 - type: loadout
   id: LoadoutNCRuniformRed
@@ -263,9 +373,64 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
+        - NCRRanger
         - NCRRangerVeteran
   items:
     - N14ClothingUniformRangerVeteranRed
+
+- type: loadout
+  id: LoadoutNCRuniformVeteran
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+        - NCRRangerVeteran
+  items:
+    - N14ClothingUniformRangerVeteran
+
+- type: loadout
+  id: LoadoutNCRuniformBlack
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+        - NCRRangerVeteran
+  items:
+    - N14ClothingUniformRangerVeteranBlack
+
+- type: loadout
+  id: LoadoutNCRuniformBlue
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+        - NCRRangerVeteran
+  items:
+    - N14ClothingUniformRangerBlue
+
+- type: loadout
+  id: LoadoutNCRuniformModif
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+        - NCRRangerVeteran
+  items:
+    - N14ClothingUniformRangerModif
+
+# MARK: Ranger Vet
 
 - type: loadout
   id: LoadoutNCRuniformHelmetDesert
@@ -332,3 +497,140 @@
       min: 216000 # 60 hours veterancy unlock "First Tour"
   items:
     - N14ClothingHeadHatRangerHelmetEliteOld
+
+# MARK: Corvax-Add
+
+- type: loadout
+  id: LoadoutNCRuniformMaskEliteVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRRangerVeteran
+      min: 216000 # 60 hours veterancy unlock "First Tour"
+  items:
+    - ClothingMaskGasRangerElite
+
+- type: loadout
+  id: LoadoutNCRuniformMaskPriceVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - ClothingMaskGasRangerPrice
+
+- type: loadout
+  id: LoadoutNCRuniformMaskModifVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - ClothingMaskGasRangerModif
+
+- type: loadout
+  id: LoadoutNCRuniformHelmetFoxVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingHeadHatRangerHelmetFox
+
+- type: loadout
+  id: LoadoutNCRuniformHelmetPriceVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingHeadHatRangerHelmetPrice
+
+- type: loadout
+  id: LoadoutNCRuniformHelmetModifVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingHeadHatRangerHelmetModif
+
+- type: loadout
+  id: LoadoutNCRuniformHelmetVR
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingHeadHatRangerHelmet
+
+- type: loadout
+  id: LoadoutNCRuniformWeathered
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingOuterRangerWeathered
+
+- type: loadout
+  id: LoadoutNCRuniformFox
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingOuterRangerFox
+
+- type: loadout
+  id: LoadoutNCRuniformPrice
+  category: Roles
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingOuterRangerPrice
+
+- type: loadout
+  id: LoadoutNCRNeckCloakRangerPoncho
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRangerVeteran
+  items:
+    - N14ClothingNeckCloakRangerPoncho

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -430,6 +430,19 @@
   items:
     - N14ClothingUniformRangerModif
 
+- type: loadout
+  id: LoadoutNCRClothingNeckOldMantle
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRRanger
+        - NCRRangerVeteran
+  items:
+    - ClothingNeckOldMantle
+
 # MARK: Ranger Vet
 
 - type: loadout

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -72,7 +72,6 @@
     - ClothingMaskGasCombat
 
 #Corvax-Add Start
-
 - type: loadout
   id: LoadoutNCRRangerCoat
   category: Roles
@@ -228,11 +227,7 @@
         - NCRRanger
   items:
     - N14ClothingNeckCloakRanger
-
 # Corvax-Add End
-
-
-# MARK: Ranger + Vet
 
 - type: loadout
   id: LoadoutNCRhatB
@@ -366,7 +361,6 @@
     - N14MedkitCombatFilled
 
 # Corvax-Add Start
-
 - type: loadout
   id: LoadoutNCRN14ClothingUniformRangerVeteranRed
   category: Roles
@@ -444,10 +438,7 @@
         - NCRRangerVeteran
   items:
     - ClothingNeckOldMantle
-
 # Corvax-Add End
-
-# MARK: Ranger Vet
 
 - type: loadout
   id: LoadoutNCRuniformHelmetDesert
@@ -516,7 +507,6 @@
     - N14ClothingHeadHatRangerHelmetEliteOld
 
 # Corvax-Add Start
-
 - type: loadout
   id: LoadoutNCRClothingMaskGasRangerElite2
   category: Roles
@@ -651,5 +641,4 @@
         - NCRRangerVeteran
   items:
     - N14ClothingNeckCloakRangerPoncho
-
 # Corvax-Add End


### PR DESCRIPTION
Добавил больше кастомизации рейнджерам в лодауты, теперь не надо будет каждый раз просить у админов щитспавн.

У обоих ролек теперь есть шлема лиса, паука а также модифицированный
Также у обоих ролек теперь есть Элитные, Паучие и Модифицированные противогазы

У обычных рейнджеров появился новый плащ (N14ClothingOuterRangerCoat), статы которого равняются 25 25 25 25
Также теперь у них есть шлема, противогазы, а также униформа ветеранов. Ещё добавил им потрёпанный противогаз, который не имеет пнв но при этом имеет текстурку зелёных линз

У ветеранов же появились в ассортименте потрёпанный, лисий и паучий плащи
Ну и сверху им добавил шлем обычных рейнджеров

Все цены лодаутов соответствуют тем что были. просто теперь вещей на выбор больше.