### PR TITLE
Восстановление Т-45 для ЗБС

### DIFF
--- a/Resources/Prototypes/Corvax/Recipes/Crafting/CraftingRecipes/bosRecipes.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Crafting/CraftingRecipes/bosRecipes.yml
@@ -7,6 +7,7 @@
   availableJobs:
   - BoSMidScribe
   - BoSWashingtonScribe
+  - BoSWestKnight
   # requiredIntelligence: 5 #TODO: Enable it after fixing the SPECIAL system
   craftTime: 10
   items:


### PR DESCRIPTION
## About the PR
Рыцарь ЗБС добавлен в требование к ролям рецепта восстановления рейдерской силовой брони.

## Why / Balance
Нужна возможность ЗБС восстанавливать силовую броню.