### PR TITLE
Добавление СБ в торгомат и часы для последователя 

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -53,7 +53,7 @@
     price: 100
 
 - type: entity
-  name: M7 Spear Rifle 
+  name: M7 Spear Rifle
   parent: N14WeaponRifleM7SpearScope
   id: N14WeaponRifleM7Spear
   description: Prototype of a next-generation rifle that never made it into service with the US Army. Only a few units were delivered for special operations testing just days before the Great War began. Finding one in the wasteland is a real jackpot. It uses a unique caliber, so finding ammunition for it is an even greater stroke of luck.
@@ -124,6 +124,7 @@
         whitelist:
           tags:
             - Magazine545Rifle
+            - MagazineDrum545Rifle
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge545Rifle
@@ -177,6 +178,7 @@
         whitelist:
           tags:
             - MagazineDrum545Rifle
+            - Magazine545Rifle
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge545Rifle

--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -124,7 +124,7 @@
         whitelist:
           tags:
             - Magazine545Rifle
-            - MagazineDrum545Rifle
+            - MagazineDrum545Rifle # Forge-change
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge545Rifle
@@ -178,7 +178,7 @@
         whitelist:
           tags:
             - MagazineDrum545Rifle
-            - Magazine545Rifle
+            - Magazine545Rifle # Forge-change
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge545Rifle

--- a/Resources/Prototypes/Corvax/Trade/trade.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade.yml
@@ -601,7 +601,7 @@
   - proto: N14ClothingHeadHatCombatHelmetCargo
     price: 35
 
-- type: storeCategoryStructured
+- type: storeCategoryStructured # Forge-change
   id: CaravanBuy2_PowerArmor
   name: "Силовая броня"
   entries:
@@ -836,7 +836,7 @@
   - CaravanBuy2_Melee
   - CaravanBuy2_Headwear
   - CaravanBuy2_Armor
-  - CaravanBuy2_PowerArmor
+  - CaravanBuy2_PowerArmor # Forge-change
   - CaravanBuy2_Rigs
   - CaravanBuy2_Medical
   - CaravanBuy2_Materials

--- a/Resources/Prototypes/Corvax/Trade/trade.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade.yml
@@ -602,6 +602,17 @@
     price: 35
 
 - type: storeCategoryStructured
+  id: CaravanBuy2_PowerArmor
+  name: "Силовая броня"
+  entries:
+  - proto: N14ClothingOuterPowerArmorRaider
+    price: 5000
+    count: 1
+  - proto: N14ClothingOuterPowerArmorT45
+    price: 7000
+    count: 1
+
+- type: storeCategoryStructured
   id: CaravanBuy2_Armor
   name: "Броня"
   entries:
@@ -825,6 +836,7 @@
   - CaravanBuy2_Melee
   - CaravanBuy2_Headwear
   - CaravanBuy2_Armor
+  - CaravanBuy2_PowerArmor
   - CaravanBuy2_Rigs
   - CaravanBuy2_Medical
   - CaravanBuy2_Materials

--- a/Resources/Prototypes/Corvax/Trade/trade.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade.yml
@@ -607,10 +607,10 @@
   entries:
   - proto: N14ClothingOuterPowerArmorRaider
     price: 5000
-    count: 1
+    count: 2
   - proto: N14ClothingOuterPowerArmorT45
     price: 7000
-    count: 1
+    count: 2
 
 - type: storeCategoryStructured
   id: CaravanBuy2_Armor

--- a/Resources/Prototypes/Corvax/Traits/speech.yml
+++ b/Resources/Prototypes/Corvax/Traits/speech.yml
@@ -28,3 +28,4 @@
         - Chinese
         - Tribal
         - Latin
+        - N14Robot

--- a/Resources/Prototypes/Corvax/Traits/speech.yml
+++ b/Resources/Prototypes/Corvax/Traits/speech.yml
@@ -28,4 +28,4 @@
         - Chinese
         - Tribal
         - Latin
-        - N14Robot
+        - N14Robot # Forge-change

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -172,6 +172,7 @@
         whitelist:
           tags:
             - N14Cartridge556Rifle
+            - Magazine556Rifle
   - type: StaticPrice
     price: 100
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -165,6 +165,8 @@
         whitelist:
           tags:
             - LongMagazine556Rifle
+            - Magazine556Rifle # Forge-change
+
       gun_chamber:
         name: Chamber
         startingItem: N14Cartridge556Rifle
@@ -172,7 +174,6 @@
         whitelist:
           tags:
             - N14Cartridge556Rifle
-            - Magazine556Rifle
   - type: StaticPrice
     price: 100
 

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
@@ -5,6 +5,9 @@
   description: job-description-followers
   playTimeTracker: Followers
   startingGear: FollowersGear
+  requirements:
+  - !type:CharacterOverallTimeRequirement
+    min: 18000 # 5 hour
   icon: "JobIconPassenger"
   supervisors: job-supervisors-followers
   accessGroups:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
@@ -5,7 +5,7 @@
   description: job-description-followers
   playTimeTracker: Followers
   startingGear: FollowersGear
-  requirements:
+  requirements: # Forge-Change
   - !type:CharacterOverallTimeRequirement
     min: 18000 # 5 hour
   icon: "JobIconPassenger"


### PR DESCRIPTION
- Комплекты силовой брони рейдерская и т45 были добавлены в торгомат в ограниченном количестве
- Роль Последователя Апокалипсиса теперь открывается после 5 часов игры
- Черта всезнайка теперь дает понимание бинарного кода
- Штурмовой винтовке теперь можно вставлять коробчатые обоймы 
- В АК112 и АК112РП теперь можно вставлять обоймы друг от друга