### PR TITLE
Двери через радиальное Z окно

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/structures/doors/access_tall.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/structures/doors/access_tall.ftl
@@ -169,3 +169,22 @@ ent-N14DoorCellMetalLockedLegionCenturion = { ent-N14DoorMetalBarTall }
 ent-N14DoorMetalSecureLockedRedLegionCenturion = { ent-N14DoorMetalBarTall }
     .suffix = Легион, Закрытый, Легион Центурион
     .desc = { ent-N14DoorMetalRedTall.desc }
+
+# Дверки через радиальное меню
+ent-N14DoorWoodSecureLockedNCRNew = { ent-N14DoorWoodWhiteTall }
+    .suffix = НКР, Закрытый
+    .desc = { ent-N14DoorWoodWhiteTall.desc }
+ent-N14DoorMetalSecureLockedNCRNew = { ent-N14DoorMetalRedTall }
+    .suffix = НКР, Закрытый
+    .desc = { ent-N14DoorMetalRedTall.desc }
+ent-N14DoorCellMetalLockedNCRNew = { ent-N14DoorMetalBarTall }
+    .suffix = НКР, Закрытый
+    .desc = { ent-N14DoorMetalBarTall.desc }
+
+ent-N14DoorWoodWhiteTallLocked = { ent-N14DoorWoodWhiteTall }
+    .suffix = НКР, Закрытый
+    .desc = { ent-N14DoorWoodWhiteTall.desc }
+ent-N14DoorCellMetalLocked = { ent-N14DoorMetalBarTall }
+    .suffix = НКР, Закрытый
+    .desc = { ent-N14DoorMetalBarTall.desc }
+

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/structures/doors/slanteddoors.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/structures/doors/slanteddoors.ftl
@@ -41,14 +41,14 @@ ent-N14DoorAirlockSlanted = воздушный шлюз
     .suffix = Наклонный
     .desc = Герметичный воздушный шлюз. Необходим для защиты от опасностей внешнего мира (или для сохранения ценного воздуха внутри).
 
-ent-N14DoorMetalBlueSlantedLoced = металлическая дверь c замком
+ent-N14DoorMetalBlueSlantedLocked = металлическая дверь c замком
     .desc = { ent-N14DoorMetalBlueSlanted.desc}
 
-ent-N14DoorMetalRedSlantedLoced = { ent-N14DoorMetalBlueSlantedLoced}
+ent-N14DoorMetalRedSlantedLocked = { ent-N14DoorMetalBlueSlantedLocked}
     .desc = { ent-N14DoorMetalRedSlanted.desc}
 
-ent-N14DoorMetalBlueAltSlantedLoced = { ent-N14DoorMetalBlueSlantedLoced}
+ent-N14DoorMetalBlueAltSlantedLocked = { ent-N14DoorMetalBlueSlantedLocked}
     .desc = { ent-N14DoorMetalBlueAltSlanted.desc}
 
-ent-N14DoorMetalBlueWindowSlantedLoced = { ent-N14DoorMetalBlueSlantedLoced}
+ent-N14DoorMetalBlueWindowSlantedLocked = { ent-N14DoorMetalBlueSlantedLocked}
     .desc = { ent-N14DoorMetalBlueWindowSlanted.desc}

--- a/Resources/Prototypes/Corvax/Entities/Structures/Doors/access_tall.yml
+++ b/Resources/Prototypes/Corvax/Entities/Structures/Doors/access_tall.yml
@@ -7,6 +7,9 @@
     access: [["CaesarLegion"]]
   - type: Wires
     layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: WoodDoorLegion 
 
 - type: entity
   parent: N14DoorMetalBarTall
@@ -17,6 +20,9 @@
     access: [["CaesarLegion"]]
   - type: Wires
     layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: CellMetalDoorLegion   
 
 - type: entity
   parent: N14DoorMetalRedTall
@@ -27,6 +33,9 @@
     access: [["CaesarLegion"]]
   - type: Wires
     layoutId: HighSec
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: MetalDoorLegion
 
 - type: entity
   parent: N14DoorWoodWhiteTall
@@ -97,6 +106,9 @@
     access: [["TownsPerson"]]
   - type: Wires
     layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: WoodDoorTown
 
 - type: entity
   parent: N14DoorMetalBarTall
@@ -107,6 +119,9 @@
     access: [["TownsPerson"]]
   - type: Wires
     layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: CellMetalDoorTown
 
 - type: entity
   parent: N14DoorMetalRedTall
@@ -117,3 +132,45 @@
     access: [["TownsPerson"]]
   - type: Wires
     layoutId: HighSec
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: MetalDoorTown
+
+- type: entity
+  parent: N14DoorWoodWhiteTall
+  id: N14DoorWoodSecureLockedNCRNew
+  suffix: NCR, Locked
+  components:
+  - type: AccessReader
+    access: [["NCR"]]
+  - type: Wires
+    layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: WoodDoorNCR
+
+- type: entity
+  parent: N14DoorMetalBarTall
+  id: N14DoorCellMetalLockedNCRNew
+  suffix: NCR, Locked
+  components:
+  - type: AccessReader
+    access: [["NCR"]]
+  - type: Wires
+    layoutId: AirlockService
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: CellMetalDoorNCR
+
+- type: entity
+  parent: N14DoorMetalRedTall
+  id: N14DoorMetalSecureLockedNCRNew
+  suffix: NCR, Locked
+  components:
+  - type: AccessReader
+    access: [["NCR"]]
+  - type: Wires
+    layoutId: HighSec
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: MetalDoorNCR

--- a/Resources/Prototypes/Corvax/Entities/Structures/Doors/slanteddoorsacces.yml
+++ b/Resources/Prototypes/Corvax/Entities/Structures/Doors/slanteddoorsacces.yml
@@ -1,59 +1,59 @@
 - type: entity
   parent: N14DoorWoodWhiteTall
-  id: N14DoorWoodWhiteTallLoced
+  id: N14DoorWoodWhiteTallLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14RadialDoorsGraph
-    node: WoodDoorLoced
+    node: WoodDoorLocked
 
 - type: entity
   parent: N14DoorMetalBarTall
-  id: N14DoorCellMetalLoced
+  id: N14DoorCellMetalLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14RadialDoorsGraph
-    node: CellMetalDoorLoced
+    node: CellMetalDoorLocked
 
 - type: entity
   parent: N14DoorMetalBlueSlanted
-  id: N14DoorMetalBlueSlantedLoced
+  id: N14DoorMetalBlueSlantedLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14DoorGraph
-    node: MetalBlueLoced
+    node: MetalBlueLocked
 
 - type: entity
   parent: N14DoorMetalRedSlanted
-  id: N14DoorMetalRedSlantedLoced
+  id: N14DoorMetalRedSlantedLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14RadialDoorsGraph
-    node: MetalRedLoced
+    node: MetalRedLocked
 
 - type: entity
   parent: N14DoorMetalBlueAltSlanted
-  id: N14DoorMetalBlueAltSlantedLoced
+  id: N14DoorMetalBlueAltSlantedLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14DoorGraph
-    node: MetalBlueAltLoced
+    node: MetalBlueAltLocked
 
 - type: entity
   parent: N14DoorMetalBlueWindowSlanted
-  id: N14DoorMetalBlueWindowSlantedLoced
+  id: N14DoorMetalBlueWindowSlantedLocked
   categories: [HideSpawnMenu]
   components:
   - type: RandomAccessKey
   - type: Construction
     graph: N14DoorGraph
-    node: MetalBlueWindowLoced
+    node: MetalBlueWindowLocked

--- a/Resources/Prototypes/Corvax/Entities/Structures/Doors/slanteddoorsacces.yml
+++ b/Resources/Prototypes/Corvax/Entities/Structures/Doors/slanteddoorsacces.yml
@@ -1,4 +1,24 @@
 - type: entity
+  parent: N14DoorWoodWhiteTall
+  id: N14DoorWoodWhiteTallLoced
+  categories: [HideSpawnMenu]
+  components:
+  - type: RandomAccessKey
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: WoodDoorLoced
+
+- type: entity
+  parent: N14DoorMetalBarTall
+  id: N14DoorCellMetalLoced
+  categories: [HideSpawnMenu]
+  components:
+  - type: RandomAccessKey
+  - type: Construction
+    graph: N14RadialDoorsGraph
+    node: CellMetalDoorLoced
+
+- type: entity
   parent: N14DoorMetalBlueSlanted
   id: N14DoorMetalBlueSlantedLoced
   categories: [HideSpawnMenu]
@@ -15,7 +35,7 @@
   components:
   - type: RandomAccessKey
   - type: Construction
-    graph: N14DoorGraph
+    graph: N14RadialDoorsGraph
     node: MetalRedLoced
 
 - type: entity

--- a/Resources/Prototypes/Corvax/Recipes/Construction/Graphs/Structures/doors.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Construction/Graphs/Structures/doors.yml
@@ -1,75 +1,116 @@
+#MARK: Двери привязанные к радиальному Z колесу.
 - type: constructionGraph
-  id: N14DoorGraph
+  id: N14RadialDoorsGraph
   start: start
   graph:
     - node: start
       actions:
         - !type:DestroyEntity {}
       edges:
-
-        - to: WoodDoor
+        # === ДЕРЕВЯННЫЕ ДВЕРИ ===
+        - to: WoodDoorTown
           completed:
             - !type:SnapToGrid { }
           steps:
             - material: WoodPlank
               amount: 4
-            - material: N14ScrapBrass
-              amount: 2
-              doAfter: 10
-
-        - to: woodDoorMakeshift
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: WoodPlank
-              amount: 3
-            - material: N14ScrapBrass
-              amount: 2
-              doAfter: 10
-# Forge-Change-Start
-        - to: MetalBlue
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: N14Iron
-              amount: 4
             - material: N14Brass
-              amount: 2
-              doAfter: 10
-
-        - to: MetalRed
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: N14Iron
-              amount: 4
-            - material: N14Brass
-              amount: 2
-              doAfter: 10
-
-        - to: MetalBlueAlt
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: N14Iron
-              amount: 4
-            - material: N14Brass
-              amount: 2
-              doAfter: 10
-
-        - to: MetalBlueWindow
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: Glass
               amount: 1
+              doAfter: 10
+
+        - to: WoodDoorLegion
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: WoodPlank
+              amount: 4
+            - material: N14Brass
+              amount: 1
+              doAfter: 10
+
+        - to: WoodDoorNCR
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: WoodPlank
+              amount: 4
+            - material: N14Brass
+              amount: 1
+              doAfter: 10
+
+        - to: WoodDoorLoced
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: WoodPlank
+              amount: 4
+            - material: N14Brass
+              amount: 1
+              doAfter: 10
+
+        # === РЕШЕТЧАТЫЕ ДВЕРИ ===
+        - to: CellMetalDoorTown
+          completed:
+            - !type:SnapToGrid { }
+          steps:
             - material: N14Iron
-              amount: 3
+              amount: 4
             - material: N14Brass
               amount: 2
               doAfter: 10
 
-        - to: MetalBlueLoced
+        - to: CellMetalDoorLegion
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: N14Iron
+              amount: 4
+            - material: N14Brass
+              amount: 2
+              doAfter: 10
+
+        - to: CellMetalDoorNCR
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: N14Iron
+              amount: 4
+            - material: N14Brass
+              amount: 2
+              doAfter: 10
+
+        - to: CellMetalDoorLoced
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: N14Iron
+              amount: 4
+            - material: N14Brass
+              amount: 2
+              doAfter: 10
+
+        # === КРАСНЫЕ МЕТАЛЛИЧЕСКИХ ДВЕРИ ===
+        - to: MetalDoorTown
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: N14Iron
+              amount: 6
+            - material: N14Brass
+              amount: 2
+              doAfter: 10
+
+        - to: MetalDoorLegion
+          completed:
+            - !type:SnapToGrid { }
+          steps:
+            - material: N14Iron
+              amount: 6
+            - material: N14Brass
+              amount: 2
+              doAfter: 10
+
+        - to: MetalDoorNCR
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -89,30 +130,24 @@
               amount: 2
               doAfter: 10
 
-        - to: MetalBlueAltLoced
+    # === УЗЛЫ ДЛЯ ДЕРЕВЯННЫХ ДВЕРЕЙ ===
+    - node: WoodDoorTown           
+      entity: N14DoorWoodSecureLockedPersonTall
+      edges:
+        - to: start
           completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: N14Iron
-              amount: 6
-            - material: N14Brass
-              amount: 2
-              doAfter: 10
-
-        - to: MetalBlueWindowLoced
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: Glass
+            - !type:SpawnPrototype
+              prototype: MaterialWoodPlank1
+              amount: 4
+            - !type:SpawnPrototype
+              prototype: N14IngotBrass1
               amount: 1
-            - material: N14Iron
-              amount: 6
-            - material: N14Brass
-              amount: 2
-              doAfter: 10
-# Forge-Change-End
-    - node: WoodDoor
-      entity: N14DoorWoodSlanted
+          steps:
+            - tool: Anchoring
+              doAfter: 15
+
+    - node: WoodDoorLegion          
+      entity: N14DoorWoodSecureLockedLegion
       edges:
         - to: start
           completed:
@@ -120,29 +155,45 @@
               prototype: MaterialWoodPlank1
               amount: 4
             - !type:SpawnPrototype
-              prototype: N14ScrapBrass1
-              amount: 2
+              prototype: N14IngotBrass1
+              amount: 1
           steps:
             - tool: Anchoring
               doAfter: 15
 
-    - node: woodDoorMakeshift
-      entity: N14DoorMakeshift
+    - node: WoodDoorNCR            
+      entity: N14DoorWoodSecureLockedNCRNew
       edges:
         - to: start
           completed:
             - !type:SpawnPrototype
               prototype: MaterialWoodPlank1
-              amount: 3 # Forge-Change
+              amount: 4
             - !type:SpawnPrototype
-              prototype: N14ScrapBrass1
-              amount: 2
+              prototype: N14IngotBrass1
+              amount: 1
           steps:
             - tool: Anchoring
               doAfter: 15
-# Forge-Change-Start
-    - node: MetalBlue
-      entity: N14DoorMetalBlueSlanted
+
+    - node: WoodDoorLoced           
+      entity: N14DoorWoodWhiteTallLoced
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: MaterialWoodPlank1
+              amount: 4
+            - !type:SpawnPrototype
+              prototype: N14IngotBrass1
+              amount: 1
+          steps:
+            - tool: Anchoring
+              doAfter: 15
+
+    # === УЗЛЫ ДЛЯ РЕШЕТЧАТЫХ ДВЕРЕЙ ===
+    - node: CellMetalDoorTown       
+      entity: N14DoorCellMetalLockedPersonTall
       edges:
         - to: start
           completed:
@@ -153,11 +204,13 @@
               prototype: N14IngotBrass1
               amount: 2
           steps:
+            - tool: Screwing
+              doAfter: 5
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalRed
-      entity: N14DoorMetalRedSlanted
+    - node: CellMetalDoorLegion    
+      entity: N14DoorCellMetalLockedLegion
       edges:
         - to: start
           completed:
@@ -168,11 +221,13 @@
               prototype: N14IngotBrass1
               amount: 2
           steps:
+            - tool: Screwing
+              doAfter: 5
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueAlt
-      entity: N14DoorMetalBlueAltSlanted
+    - node: CellMetalDoorNCR       
+      entity: N14DoorCellMetalLockedNCRNew
       edges:
         - to: start
           completed:
@@ -183,28 +238,13 @@
               prototype: N14IngotBrass1
               amount: 2
           steps:
+            - tool: Screwing
+              doAfter: 5
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueWindow
-      entity: N14DoorMetalBlueWindowSlanted
-      edges:
-        - to: start
-          completed:
-            - !type:SpawnPrototype
-              prototype: SheetGlass1
-            - !type:SpawnPrototype
-              prototype: N14IngotIron1
-              amount: 3
-            - !type:SpawnPrototype
-              prototype: N14IngotBrass1
-              amount: 2
-          steps:
-            - tool: Anchoring
-              doAfter: 15
-
-    - node: MetalBlueLoced
-      entity: N14DoorMetalBlueSlantedLoced
+    - node: CellMetalDoorLoced      
+      entity: N14DoorCellMetalLoced
       edges:
         - to: start
           completed:
@@ -220,8 +260,9 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueAltLoced
-      entity: N14DoorMetalBlueAltSlantedLoced
+    # === УЗЛЫ ДЛЯ КРАСНЫХ МЕТАЛЛИЧЕСКИХ ДВЕРЕЙ ===
+    - node: MetalDoorTown           
+      entity: N14DoorMetalSecureLockedPersonTall
       edges:
         - to: start
           completed:
@@ -237,13 +278,11 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueWindowLoced
-      entity: N14DoorMetalBlueWindowSlantedLoced
+    - node: MetalDoorLegion         
+      entity: N14DoorMetalSecureLockedRedLegion
       edges:
         - to: start
           completed:
-            - !type:SpawnPrototype
-              prototype: SheetGlass1
             - !type:SpawnPrototype
               prototype: N14IngotIron1
               amount: 6
@@ -255,4 +294,37 @@
               doAfter: 5
             - tool: Anchoring
               doAfter: 15
-# Forge-Change-End
+
+    - node: MetalDoorNCR            
+      entity: N14DoorMetalSecureLockedNCRNew
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: N14IngotIron1
+              amount: 6
+            - !type:SpawnPrototype
+              prototype: N14IngotBrass1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 5
+            - tool: Anchoring
+              doAfter: 15
+  
+    - node: MetalRedLoced          
+      entity: N14DoorMetalRedSlantedLoced
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: N14IngotIron1
+              amount: 6
+            - !type:SpawnPrototype
+              prototype: N14IngotBrass1
+              amount: 2
+          steps:
+            - tool: Screwing
+              doAfter: 5
+            - tool: Anchoring
+              doAfter: 15  

--- a/Resources/Prototypes/Corvax/Recipes/Construction/Graphs/Structures/doors.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Construction/Graphs/Structures/doors.yml
@@ -38,7 +38,7 @@
               amount: 1
               doAfter: 10
 
-        - to: WoodDoorLoced
+        - to: WoodDoorLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -79,7 +79,7 @@
               amount: 2
               doAfter: 10
 
-        - to: CellMetalDoorLoced
+        - to: CellMetalDoorLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -120,7 +120,7 @@
               amount: 2
               doAfter: 10
 
-        - to: MetalRedLoced
+        - to: MetalRedLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -176,8 +176,8 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: WoodDoorLoced           
-      entity: N14DoorWoodWhiteTallLoced
+    - node: WoodDoorLocked           
+      entity: N14DoorWoodWhiteTallLocked
       edges:
         - to: start
           completed:
@@ -243,8 +243,8 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: CellMetalDoorLoced      
-      entity: N14DoorCellMetalLoced
+    - node: CellMetalDoorLocked      
+      entity: N14DoorCellMetalLocked
       edges:
         - to: start
           completed:
@@ -312,8 +312,8 @@
             - tool: Anchoring
               doAfter: 15
   
-    - node: MetalRedLoced          
-      entity: N14DoorMetalRedSlantedLoced
+    - node: MetalRedLocked          
+      entity: N14DoorMetalRedSlantedLocked
       edges:
         - to: start
           completed:

--- a/Resources/Prototypes/Corvax/Recipes/Crafting/Construction/structures.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Crafting/Construction/structures.yml
@@ -65,10 +65,10 @@
 
 # MARK: Двери Замок
 - type: construction
-  id: N14DoorMetalBlueSlantedLoced
+  id: N14DoorMetalBlueSlantedLocked
   graph: N14DoorGraph
   startNode: start
-  targetNode: MetalBlueLoced
+  targetNode: MetalBlueLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
@@ -81,10 +81,10 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: N14DoorMetalBlueAltSlantedLoced
+  id: N14DoorMetalBlueAltSlantedLocked
   graph: N14DoorGraph
   startNode: start
-  targetNode: MetalBlueAltLoced
+  targetNode: MetalBlueAltLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
@@ -97,10 +97,10 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: N14DoorMetalBlueWindowSlantedLoced
+  id: N14DoorMetalBlueWindowSlantedLocked
   graph: N14DoorGraph
   startNode: start
-  targetNode: MetalBlueWindowLoced
+  targetNode: MetalBlueWindowLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
@@ -289,10 +289,10 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: N14DoorWoodWhiteTallLoced
+  id: N14DoorWoodWhiteTallLocked
   graph: N14RadialDoorsGraph
   startNode: start
-  targetNode: WoodDoorLoced
+  targetNode: WoodDoorLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
@@ -354,10 +354,10 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: N14DoorCellMetalLoced
+  id: N14DoorCellMetalLocked
   graph: N14RadialDoorsGraph
   startNode: start
-  targetNode: CellMetalDoorLoced
+  targetNode: CellMetalDoorLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter
@@ -419,10 +419,10 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: N14DoorMetalRedSlantedLoced
+  id: N14DoorMetalRedSlantedLocked
   graph: N14RadialDoorsGraph
   startNode: start
-  targetNode: MetalRedLoced
+  targetNode: MetalRedLocked
   category: construction-category-structures
   objectType: Structure
   placementMode: SnapgridCenter

--- a/Resources/Prototypes/Corvax/Recipes/Crafting/Construction/structures.yml
+++ b/Resources/Prototypes/Corvax/Recipes/Crafting/Construction/structures.yml
@@ -73,25 +73,9 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  hide: false
+  hide: true
   icon:
     sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalblue.rsi
-    state: closed
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
-  id: N14DoorMetalRedSlantedLoced
-  graph: N14DoorGraph
-  startNode: start
-  targetNode: MetalRedLoced
-  category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  hide: false
-  icon:
-    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalred.rsi
     state: closed
   conditions:
     - !type:TileNotBlocked
@@ -105,7 +89,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  hide: false
+  hide: true
   icon:
     sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalbluealt.rsi
     state: closed
@@ -121,13 +105,14 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  hide: false
+  hide: true
   icon:
     sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalbluewindow.rsi
     state: closed
   conditions:
     - !type:TileNotBlocked
 
+#MARK: Крест
 - type: construction
   name: Cross
   id: Cross
@@ -145,6 +130,7 @@
   conditions:
     - !type:TileNotBlocked
 
+#MARK: Барикады.
 - type: construction
   id: N14BarricadeTanktrapRusty
   graph: N14BarricadeTanktrapRustyGraph
@@ -189,7 +175,8 @@
   hide: false
   conditions:
     - !type:TileNotBlocked
-# Carpets
+
+#MARK: Ковры
 - type: construction
   id: N14RugRed
   graph: N14RugRedGraph
@@ -250,4 +237,199 @@
   conditions:
     - !type:TileNotBlocked
 
-#Flags
+#MARK: Двери привязанные к радиальному Z колесу.
+    
+# === ДЛЯ ВСЕХ ДЕРЕВЯННЫХ ДВЕРЕЙ ===
+- type: construction
+  id: N14DoorWoodSecureLockedPersonTall
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: WoodDoorTown
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/wood.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorWoodSecureLockedLegion
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: WoodDoorLegion
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/wood.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorWoodSecureLockedNCRNew
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: WoodDoorNCR
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/wood.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorWoodWhiteTallLoced
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: WoodDoorLoced
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/wood.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+# === ДЛЯ ВСЕХ РЕШЕТЧАТЫХ ДВЕРЕЙ ===
+- type: construction
+  id: N14DoorCellMetalLockedPersonTall
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: CellMetalDoorTown
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metal_bar.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorCellMetalLockedLegion
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: CellMetalDoorLegion
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metal_bar.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorCellMetalLockedNCRNew
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: CellMetalDoorNCR
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metal_bar.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorCellMetalLoced
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: CellMetalDoorLoced
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metal_bar.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+# === ДЛЯ ВСЕХ КРАСНЫХ МЕТАЛЛИЧЕСКИХ ДВЕРЕЙ ===
+- type: construction
+  id: N14DoorMetalSecureLockedPersonTall
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: MetalDoorTown
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalred.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorMetalSecureLockedRedLegion
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: MetalDoorLegion
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalred.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorMetalSecureLockedNCRNew
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: MetalDoorNCR
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalred.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: N14DoorMetalRedSlantedLoced
+  graph: N14RadialDoorsGraph
+  startNode: start
+  targetNode: MetalRedLoced
+  category: construction-category-structures
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: true
+  icon:
+    sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalred.rsi
+    state: closed
+  conditions:
+    - !type:TileNotBlocked

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/metals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/metals.yml
@@ -198,6 +198,52 @@
           Quantity: 5
         - ReagentId: Zinc
           Quantity: 5
+  - type: UserInterface
+    interfaces:
+      enum.RadialSelectorUiKey.Key:
+        type: RadialSelectorMenuBUI
+  - type: ActivatableUI
+    key: enum.RadialSelectorUiKey.Key
+    inHandsOnly: true
+    requireActiveHand: false
+  - type: ShortConstruction
+    entries:
+    - category:
+        name: Town doors
+        icon:
+          sprite: Corvax/Structures/Wallmount/flag.rsi
+          state: flag_bazar
+        entries:
+          - prototype: N14DoorWoodSecureLockedPersonTall
+          - prototype: N14DoorCellMetalLockedPersonTall     
+          - prototype: N14DoorMetalSecureLockedPersonTall
+    - category:
+        name: NCR doors
+        icon:
+          sprite: _Nuclear14/Structures/Wallmounts/walldecor.rsi
+          state: flag_ncr
+        entries:
+          - prototype: N14DoorWoodSecureLockedNCRNew
+          - prototype: N14DoorCellMetalLockedNCRNew
+          - prototype: N14DoorMetalSecureLockedNCRNew
+    - category:
+        name: Legion doors
+        icon:
+          sprite: _Nuclear14/Structures/Wallmounts/walldecor.rsi
+          state: flag_legion
+        entries:
+          - prototype: N14DoorWoodSecureLockedLegion
+          - prototype: N14DoorCellMetalLockedLegion
+          - prototype: N14DoorMetalSecureLockedRedLegion
+    - category:
+        name: Key doors
+        icon:
+          sprite: _Nuclear14/Objects/Misc/tapes_cards.rsi
+          state: grey
+        entries:
+          - prototype: N14DoorWoodWhiteTallLoced
+          - prototype: N14DoorCellMetalLoced
+          - prototype: N14DoorMetalRedSlantedLoced              
 
 - type: entity
   parent: N14IngotBrass

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/metals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/metals.yml
@@ -241,9 +241,9 @@
           sprite: _Nuclear14/Objects/Misc/tapes_cards.rsi
           state: grey
         entries:
-          - prototype: N14DoorWoodWhiteTallLoced
-          - prototype: N14DoorCellMetalLoced
-          - prototype: N14DoorMetalRedSlantedLoced              
+          - prototype: N14DoorWoodWhiteTallLocked
+          - prototype: N14DoorCellMetalLocked
+          - prototype: N14DoorMetalRedSlantedLocked              
 
 - type: entity
   parent: N14IngotBrass

--- a/Resources/Prototypes/_Nuclear14/Recipes/Construction/Graphs/Structures/doors.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Construction/Graphs/Structures/doors.yml
@@ -69,7 +69,7 @@
               amount: 2
               doAfter: 10
 
-        - to: MetalBlueLoced
+        - to: MetalBlueLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -79,7 +79,17 @@
               amount: 2
               doAfter: 10
 
-        - to: MetalRedLoced
+        # - to: MetalRedLocked
+        #   completed:
+        #     - !type:SnapToGrid { }
+        #   steps:
+        #     - material: N14Iron
+        #       amount: 6
+        #     - material: N14Brass
+        #       amount: 2
+        #       doAfter: 10
+
+        - to: MetalBlueAltLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -89,17 +99,7 @@
               amount: 2
               doAfter: 10
 
-        - to: MetalBlueAltLoced
-          completed:
-            - !type:SnapToGrid { }
-          steps:
-            - material: N14Iron
-              amount: 6
-            - material: N14Brass
-              amount: 2
-              doAfter: 10
-
-        - to: MetalBlueWindowLoced
+        - to: MetalBlueWindowLocked
           completed:
             - !type:SnapToGrid { }
           steps:
@@ -203,8 +203,8 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueLoced
-      entity: N14DoorMetalBlueSlantedLoced
+    - node: MetalBlueLocked
+      entity: N14DoorMetalBlueSlantedLocked
       edges:
         - to: start
           completed:
@@ -220,8 +220,8 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueAltLoced
-      entity: N14DoorMetalBlueAltSlantedLoced
+    - node: MetalBlueAltLocked
+      entity: N14DoorMetalBlueAltSlantedLocked
       edges:
         - to: start
           completed:
@@ -237,8 +237,8 @@
             - tool: Anchoring
               doAfter: 15
 
-    - node: MetalBlueWindowLoced
-      entity: N14DoorMetalBlueWindowSlantedLoced
+    - node: MetalBlueWindowLocked
+      entity: N14DoorMetalBlueWindowSlantedLocked
       edges:
         - to: start
           completed:


### PR DESCRIPTION
Теперь удерживая слиток латуни в руках можно будет открыть радиальное окно для постройки дверей через нажатие клавиши Z.

Городские, НКР, Легион получили возможность возведения своих дверей в 3-ёх видах. Деревянная, стальная, решётчатая.
Все двери с ключом были скрыты из G-меню строительства и перемещены в радиальное Z окно в 3-ёх видах.