### PR TITLE
Лодаут обновление

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/catalog/fills/items/belts.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/catalog/fills/items/belts.ftl
@@ -19,7 +19,7 @@ ent-N14ClothingBeltPlantFilled = { ent-ClothingBeltPlant }
     .desc = { ent-ClothingBeltPlant.desc }
 
 # пояс фермера 
-ent-ClothingBeltFarmerFilled = { ent-ClothingBeltFarmer }
+ent-N14ClothingBeltFarmerFilled = { ent-ClothingBeltFarmer }
     .suffix = Заполненный
     .desc = { ent-ClothingBeltFarmer.desc }
 

--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/clothing/head/helmets.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/_nuclear14/entities/clothing/head/helmets.ftl
@@ -64,8 +64,14 @@ ent-N14ClothingHeadHatEnclaveHelmetMarine = шлем пехоты Анклава
     .desc = Шлем элитного бойца Анклава, готового выполнить любой приказ.
 
 # Новая Калифорнийская Республика (НКР) 
-ent-N14ClothingHeadHatNCRHelmetMetal = металлический шлем НКР
+ent-N14ClothingHeadHatNCRHelmetMetal =  Шлем НКР металлический
     .desc = Простой шлем, защищающий головы бойцов, отстаивающих идеалы НКР.
+ent-N14ClothingHeadHatNCRHelmetMetalSnow = Шлем НКР металлический зимний
+    .desc =  Округлый шлем НКР, обеспечивающий некоторую защиту. Этот экземпляр покрыт зимней краской.
+ent-N14ClothingHeadHatNCRHelmetMetalWoods = Шлем НКР металлический лесной
+    .desc = Простой шлем, защищающий головы бойцов, отстаивающих идеалы НКР. Этот шлем покрыт лесным камуфляжем.
+ent-N14ClothingHeadHatNCRHelmetMetalGhillie = Шлем НКР металлический с маскировочной сеткой
+    .desc = Округлый шлем НКР, обеспечивающий некоторую защиту. Этот экземпляр покрыт лесным камуфляжем типа "маскировочная сеть".
 ent-N14ClothingHeadHatNCRHelmetMetalMilitaryPolice = полицейский шлем НКР
     .desc = Шлем военной полиции НКР - символ порядка и закона в мире хаоса.
 ent-N14ClothingHeadHatNCRHelmetMetalMedic = медицинский шлем НКР
@@ -88,14 +94,10 @@ ent-N14ClothingHeadHatRangerHelmetSnowFox = боевой шлем рейндже
     .desc = { ent-N14ClothingHeadHatRangerHelmetFox.desc }
 ent-N14ClothingHeadHatRangerHelmetModif = модифицированный боевой шлем рейнджера
     .desc = Усиленный шлем, который носят рейнджеры в самых опасных уголках Пустоши. Маска намертво приварена к корпусу, а сам шлем явно подвергался кустарным модификациям.
-ent-N14ClothingHeadHatNCRHelmetMetalWoods = Лесной металлический шлем НКР
-    .desc = Простой шлем, защищающий головы бойцов, отстаивающих идеалы НКР. Этот шлем покрыт лесным камуфляжем.
 ent-N14ClothingHeadHatNCRHelmet = шлем бойца НКР
     .desc = Простой шлем, защищающий головы бойцов, отстаивающих идеалы НКР. Этот шлем покрыт пустынным камуфляжем.
 ent-N14ClothingHeadHatNCRHelmetSnow = шлем бойца НКР зимний
     .desc = Простой шлем, защищающий головы бойцов, отстаивающих идеалы НКР. Этот шлем покрыт зимним камуфляжем.
-ent-N14ClothingHeadHatNCRHelmetMetalGhillie = Шлем НКР с маскировочной сеткой
-    .desc = Округлый шлем НКР, обеспечивающий некоторую защиту. Этот экземпляр покрыт лесным камуфляжем типа "маскировочная сеть".
 ent-N14ClothingHeadHatNCRHelmetMetalRadioSnow = Шлем радиста НКР
     .desc = Округлый шлем НКР, обеспечивающий некоторую защиту. Обычно используется радистами и унтер-офицерами.
 ent-N14ClothingHeadHatNCRHelmetMetalRadioWood = { ent-N14ClothingHeadHatNCRHelmetMetalRadioSnow }
@@ -103,7 +105,7 @@ ent-N14ClothingHeadHatNCRHelmetMetalRadioWood = { ent-N14ClothingHeadHatNCRHelme
 ent-N14ClothingHeadHatNCRCombatHelmet = боевой шлем НКР
     .desc = Стальной шлем, обеспечивающий лучшие защитные свойства по сравнению с обычным. Ожидайте проблемы с шеей если носите его все время.
 ent-N14ClothingHeadHatNCRCombatHelmetSnow = боевой шлем НКР зимний
-    .desc = { N14ClothingHeadHatNCRCombatHelmetSnow.desc }
+    .desc = { ent-N14ClothingHeadHatNCRCombatHelmet.desc }
 
 # Племя 
 ent-N14ClothingHeadHatTribalPowerhelm = тяжёлый шлем старейшины

--- a/Resources/Prototypes/Corvax/Catalog/Fills/belt.yml
+++ b/Resources/Prototypes/Corvax/Catalog/Fills/belt.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: ClothingBeltFarmerFilled
+  id: N14ClothingBeltFarmerFilled
   parent: ClothingBeltFarmer
   suffix: Filled
   components:
@@ -7,4 +7,5 @@
     contents:
     - id: HydroponicsToolMiniHoe
     - id: HydroponicsToolSpade
-    - id: RobustHarvestChemistryBottle # used by tribal farmers, leave robust?
+    - id: N14FertilizerChemistryBottle 
+      amount: 2

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Head/helmets.yml
@@ -451,7 +451,7 @@
     sprite: Corvax/Clothing/Head/Helmets/falloutNCRcombathelmetSnow.rsi
 
 - type: entity
-  parent: N14ClothingHeadHatBaseHelmetMetal # \Prototypes\_Nuclear14\Entities\Clothing\Head\helmets.yml
+  parent: N14ClothingHeadHatBaseHelmetWithHair # \Prototypes\_Nuclear14\Entities\Clothing\Head\helmets.yml
   id: N14ClothingHeadHatNCRHelmet
   name: NCR helmet
   description: A rounded NCR helmet offering some protection. This one is covered on classic desert camo.

--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
@@ -13,7 +13,7 @@
 
 - type: loadout
   id: LoadoutLegionVenatorReconnaissanceArmor
-  category: Roles
+  category: Outer
   cost: 4
   exclusive: true
   requirements:
@@ -71,7 +71,7 @@
 
 - type: loadout
   id: LoadoutLegionDeadVeteranArmor
-  category: Roles
+  category: Outer
   cost: 2
   exclusive: true
   requirements:
@@ -86,7 +86,7 @@
 
 - type: loadout
   id: LoadoutLegionDeadPrimeArmor
-  category: Roles
+  category: Outer
   cost: 2
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Corvax/Loadouts/belts.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/belts.yml
@@ -1,0 +1,89 @@
+- type: loadout
+  id: N14LoadoutClothingBeltFarmerFilled
+  category: Items
+  cost: 3
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 3600
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault        
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingBeltFarmerFilled
+
+- type: loadout
+  id: N14LoadoutClothingBeltStorageWaistbag
+  category: Items
+  cost: 3
+  requirements:      
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - ClothingBeltStorageWaistbag
+
+- type: loadout
+  id: N14LoadoutClothingBeltRope
+  category: Items
+  cost: 4
+  requirements:      
+    - !type:OverallTimeRequirement
+      min: 3600
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault        
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - ClothingBeltRope
+
+- type: loadout
+  id: N14LoadoutPlantBag
+  category: Items
+  cost: 2
+  requirements:   
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault      
+  items:
+    - PlantBag
+
+- type: loadout
+  id: N14LoadoutOreBag
+  category: Items
+  cost: 2
+  requirements:   
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault      
+  items:
+    - OreBag
+
+- type: loadout
+  id: N14LoadoutChemBag
+  category: Items
+  cost: 2
+  requirements:   
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault      
+  items:
+    - ChemBag

--- a/Resources/Prototypes/Corvax/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/outerClothing.yml
@@ -19,26 +19,6 @@
     - N14ClothingOuterPainspike
 
 - type: loadout
-  id: N14LoadoutOuterLeatherArmor
-  category: Outer
-  cost: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Townsfolk
-        - Wastelander
-    - !type:CharacterJobRequirement # Forge-Change
-      inverted: true
-      jobs:
-      - BoSMidSerf
-      - CaesarLegionSlave
-      - NCRPisoner
-  items:
-    - N14ClothingOuterLeatherArmor
-
-- type: loadout
   id: N14ClothingOuterReinforcedLeatherArmor
   category: Outer
   cost: 3

--- a/Resources/Prototypes/Corvax/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/outerClothing.yml
@@ -1,0 +1,144 @@
+- type: loadout
+  id: N14ClothingOuterPainspike
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterPainspike
+
+- type: loadout
+  id: N14LoadoutOuterLeatherArmor
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterLeatherArmor
+
+- type: loadout
+  id: N14ClothingOuterReinforcedLeatherArmor
+  category: Outer
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterReinforcedLeatherArmor
+
+- type: loadout
+  id: N14ClothingOuterLightLeatherArmor
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterLightLeatherArmor
+
+- type: loadout
+  id: N14ClothingOuterTireArmor
+  category: Outer
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterTireArmor        
+
+- type: loadout
+  id: N14ClothingOuterVestLeather
+  category: Outer
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterVestLeather 
+
+- type: loadout
+  id: N14ClothingOuterInsectArmor
+  category: Outer
+  cost: 4
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Townsfolk
+        - Wastelander
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14ClothingOuterInsectArmor 
+
+
+
+
+

--- a/Resources/Prototypes/Corvax/Loadouts/weapon.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/weapon.yml
@@ -1,0 +1,366 @@
+# Pistols
+- type: loadout
+  id: N14WeaponRevolver10mm
+  category: Weapons
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponRevolver10mm
+
+- type: loadout
+  id: N14WeaponRevolver44Tribal
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponRevolver44Tribal
+
+#Shotgun
+- type: loadout
+  id: N14WeaponShotgunCaravan
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 3600
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponShotgunCaravan
+
+# SMG
+- type: loadout
+  id: N14WeaponSMG10mmPipe
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 7200
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponSMG10mmPipe
+
+#Rifle
+- type: loadout
+  id: N14WeaponSniper556VarmintRifle
+  category: Weapons
+  cost: 4
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 4800
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponSniper556VarmintRifle
+
+#Laser
+- type: loadout
+  id: N14WeaponLaserPistol
+  category: Weapons
+  cost: 4
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 12800
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponLaserPistol
+
+- type: loadout
+  id: N14WeaponLaserRifleMakeshift
+  category: Weapons
+  cost: 8
+  requirements:
+    - !type:OverallTimeRequirement
+      min: 16800
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGuns
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14WeaponLaserRifleMakeshift
+
+#Ammo
+- type: loadout
+  id: N14MagazinePistol22lr
+  category: Weapons
+  cost: 1
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14MagazinePistol22lr
+    - N14MagazinePistol22lr
+    - N14MagazinePistol22lr
+    - N14MagazinePistol22lr
+
+- type: loadout
+  id: SpeedLoader10
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - SpeedLoader10
+    - SpeedLoader10
+    - SpeedLoader10
+    - SpeedLoader10
+
+- type: loadout
+  id: SpeedLoader44
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      departments:
+        - Wastelander
+        - Townsfolk
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - SpeedLoader44
+    - SpeedLoader44
+
+- type: loadout
+  id: N14MagazinePistol10mm
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14MagazinePistol10mm
+    - N14MagazinePistol10mm
+
+- type: loadout
+  id: MagazineBox12gauge
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - MagazineBox12gauge
+
+- type: loadout
+  id: MagazineBox20gauge
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - MagazineBox20gauge
+
+- type: loadout
+  id: N14MagazinePistol9mm
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14MagazinePistol9mm
+    - N14MagazinePistol9mm
+
+- type: loadout
+  id: N14MagazineSMG10mm
+  category: Weapons
+  cost: 4
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+  items:
+    - N14MagazineSMG10mm
+    - N14MagazineSMG10mm
+
+- type: loadout
+  id: Magazine556Rifle
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      departments:
+        - Wastelander
+        - Townsfolk
+  items:
+    - Magazine556Rifle
+
+- type: loadout
+  id: N14PowerCellSmall
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmo
+    - !type:CharacterJobRequirement # Forge-Change
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPisoner
+    - !type:CharacterDepartmentRequirement # Forge-Change
+      departments:
+        - Wastelander
+        - Townsfolk
+  items:
+    - N14PowerCellSmall
+    - N14PowerCellSmall

--- a/Resources/Prototypes/Corvax/Trade/trade_catalog_city.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade_catalog_city.yml
@@ -354,7 +354,7 @@
     price: 15
   - proto: N14ClothingHeadHatPrewarMilitaryHelmet
     price: 35
-  - proto: N14ClothingHeadHatCombatHelmetCargo
+  - proto: N14ClothingHeadHatCombatHelmet
     price: 35
 
 - type: storeCategoryStructured # Forge-change

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -32,6 +32,7 @@
         - JawsOfLife
         - GPS
         - WeldingMask
+        - N14ClothingEyesGlassesWelding #Forge-add
       components:
         - SprayPainter
         - NetworkConfigurator
@@ -268,7 +269,9 @@
         - PillCanister
         - Radio
         - DiscreteHealthAnalyzer
-        - N14Bandage # Corvax-Change
+        - N14Bandage # Forge-start-Change
+        - N14HealingPowder
+        - N14HealingPoultice # Forge-end-Change
       components:
         - SurgeryTool # Shitmed Change
         - Hypospray

--- a/Resources/Prototypes/_Forge/Entities/Objects/Specific/сhemistry-bottles.yml
+++ b/Resources/Prototypes/_Forge/Entities/Objects/Specific/сhemistry-bottles.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: N14FertilizerChemistryBottle
+  name: бутылочка удобрения
+  description: Это повысит скорость созревание растений.
+  parent: BaseChemistryBottleFilled
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Fertilizer
+          Quantity: 30

--- a/Resources/Prototypes/_Nuclear14/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Fills/Items/belt.yml
@@ -47,8 +47,9 @@
     contents:
     - id: HydroponicsToolMiniHoe # TODO: Replace with new tools
     - id: HydroponicsToolSpade # TODO: Replace with new tools
-    - id: RobustHarvestChemistryBottle # TODO: Replace with new tools
-
+    - id: N14FertilizerChemistryBottle # TODO: Replace with new tools
+      amount: 2
+      
 - type: entity
   id: N14WalletLottaCash
   parent: N14Wallet

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/helmets.yml
@@ -78,6 +78,22 @@
 
 - type: entity
   parent: ClothingHeadBase
+  id: N14ClothingHeadHatBaseHelmetWithHair
+  abstract: true
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
+    priceMultiplier: 0.5
+  - type: ExplosionResistance
+    damageCoefficient: 0.95
+
+- type: entity
+  parent: ClothingHeadBase
   id: N14ClothingHeadHatBaseHelmetMetal
   name: metal helmet
   abstract: true
@@ -389,7 +405,7 @@
     sprite: _Nuclear14/Clothing/Head/FalloutHelmets/ncrhelmetmp.rsi
 
 - type: entity
-  parent: ClothingHeadBase # Forge-Change
+  parent: N14ClothingHeadHatBaseHelmetWithHair 
   id: N14ClothingHeadHatNCRHelmetMetalMedic
   name: NCR medic helmet
   description: A rounded NCR helmet offering some protection, worn by Field Medics.

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_bos_midwest.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_bos_midwest.yml
@@ -1,7 +1,7 @@
 - type: loadout
   id: LoadoutBoSMidwestSquire
   category: Outer
-  cost: 6 # Forge-Change
+  cost: 8 # Forge-Change
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement
@@ -12,21 +12,7 @@
       min: 54000 # 15 hours veterancy unlock
   items:
     - N14ClothingOuterMidwestReconArmor
-
-- type: loadout
-  id: LoadoutBoSMidwestReconHelmet
-  category: Head
-  cost: 6
-  exclusive: true
-  requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-        - BoSMidPaladin
-    - !type:CharacterPlaytimeRequirement
-      tracker: BoSMidPaladin
-      min: 54000 # 15 hours veterancy unlock
-  items:
-    - N14ClothingHeadHatBrotherhoodMidwestHelmetRecon
+    - N14ClothingHeadHatBrotherhoodMidwestHelmetRecon #Forge-add
 
 - type: loadout
   id: LoadoutClothingOuterMBoSSquireArmor

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -276,20 +276,20 @@
     - N14FoodPorkBeans
 
 # Misc
-- type: loadout
-  id: N14CurrencyCap100
-  category: Items
-  cost: 5
-  requirements:
-  - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-      - Vault  
-  - !type:CharacterJobRequirement # Forge-Change
-      inverted: true
-      jobs:
-      - BoSMidSerf
-      - CaesarLegionSlave
-      - NCRPisoner
-  items:
-    - N14CurrencyCap100
+# - type: loadout #Forge-change
+#   id: N14CurrencyCap100
+#   category: Items
+#   cost: 5
+#   requirements:
+#   - !type:CharacterDepartmentRequirement
+#       inverted: true
+#       departments:
+#       - Vault  
+#   - !type:CharacterJobRequirement # Forge-Change
+#       inverted: true
+#       jobs:
+#       - BoSMidSerf
+#       - CaesarLegionSlave
+#       - NCRPisoner
+#   items:
+#     - N14CurrencyCap100

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -341,7 +341,7 @@
 - type: loadout
   id: N14LoadoutOuterLeatherArmor
   category: Outer
-  cost: 3
+  cost: 2 # Forge-Change
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -361,7 +361,7 @@
 - type: loadout
   id: N14LoadoutOuterMetalArmor
   category: Outer
-  cost: 3
+  cost: 4 #Forge-change
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -381,7 +381,7 @@
 - type: loadout
   id: N14LoadoutOuterRaiderBadlands
   category: Outer
-  cost: 3
+  cost: 1 # Forge-Change
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -401,7 +401,7 @@
 - type: loadout
   id: N14LoadoutOuterRaiderBlastmaster
   category: Outer
-  cost: 3
+  cost: 2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -2,7 +2,7 @@
 - type: loadout
   id: N14WeaponPistol22lr
   category: Weapons
-  cost: 2
+  cost: 1 # Forge-Change
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutGuns
@@ -80,10 +80,10 @@
     - N14WeaponPistol9mm
 
 # Shotguns
-- type: loadout
-  id: N14WeaponShotgunDoubleBarrel
+- type: loadout # Forge-change-start
+  id: N14WeaponShotgunPipe
   category: Weapons
-  cost: 2
+  cost: 3
   requirements:
     - !type:OverallTimeRequirement
       min: 3600
@@ -100,7 +100,7 @@
       - CaesarLegionSlave
       - NCRPisoner
   items:
-    - N14WeaponShotgunDoubleBarrel
+    - N14WeaponShotgunPipe # Forge-change-end
 
 # Rifles
 
@@ -130,7 +130,7 @@
 - type: loadout
   id: N14SpeedLoader9
   category: Weapons
-  cost: 1
+  cost: 2 # Forge-Change
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutAmmo
@@ -144,7 +144,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-  items:
+  items: #Forge-change
+    - SpeedLoader9
+    - SpeedLoader9
+    - SpeedLoader9
     - SpeedLoader9
 
 # Melee

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalfarmer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalfarmer.yml
@@ -38,7 +38,7 @@
     shoes: N14ClothingShoesTribal
     gloves: N14ClothingHandsGlovesTribal
     back: N14ClothingBackpackTrekker # Forge-Change
-    belt: ClothingBeltFarmerFilled # Forge-Change
+    belt: N14ClothingBeltFarmerFilled # Forge-Change
     pocket1: N14TribalKnife
     pocket2: Triballoadoutkits #given to them until i sort out this role
     id: N14IDTribeEnforcerPendant

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
@@ -21,7 +21,7 @@
     back: N14ClothingBackpackExplorer # Forge-Change
     shoes: N14ClothingBootsLeather
     outerClothing: ClothingOuterApronBotanist
-    belt: ClothingBeltFarmerFilled
+    belt: N14ClothingBeltFarmerFilled
     id: N14IDPassportWasteFarmer
   innerClothingSkirt: N14ClothingUniformJumpsuitBrahminFarmer #placeholder
   satchel: N14ClothingBackpackSatchelWastelanderFilled
@@ -29,6 +29,8 @@
   storage: # Forge-Change
     back:
     - N14BoxPlasticFilledWastelander
-
+    - Bucket
+    - PlantBag
+    
 - type: playTimeTracker
   id: Farmer

--- a/Resources/Prototypes/_Nuclear14/tags.yml
+++ b/Resources/Prototypes/_Nuclear14/tags.yml
@@ -196,6 +196,15 @@
 - type: Tag
   id: N14Welder
 
+- type: Tag # forge-add
+  id: N14HealingPowder
+
+- type: Tag # forge-add
+  id: N14HealingPoultice
+
+- type: Tag # forge-add
+  id: N14ClothingEyesGlassesWelding
+
 #MARK: Guns types.
 - type: Tag
   id: Revolver


### PR DESCRIPTION
Добавлен перевод снежному металлическому шлему НКР
Починено описание для боевого шлема МК2 НКР зимнего
В торгомате изменён боевой шлем (карго) на боевой шлем (без приписки), ибо у (карго) значения, как у боевого МК2.
Изменена склянка робаста в поясе фермера на склянку удобрения
В стартовое снаряжение фермера добавлено ведро и сумка для растений
Для не плотно прилегающих шлемов был добавлен новый парент N14ClothingHeadHatBaseHelmetWithHair, он был добавлен для шляпок FNV НКР, но не коснулся металлических шлемов НКР.
В категорию outerClothing лодаута была добавлена разная броня не превышающая 30% защиты и немного изменены значения стоимости в очках другой брони.
В категории weapon лодаута были изменены некоторые цены, а так же добавлены следующие оружия - револьвер 10мм, лазерный пистолет, дробовик каравана, самодельный дробовик на 12, варминт-винтовка, самодельная лазерная винтовка, револьвер 44 на 4 патрона, мусорный смг 10мм.
Там же в категории weapon лодаута были добавлены новые патроны и магазины. Некоторые магазины выдаются в множеством числе, а не по одному в зависимости от калибра.
В пояс медицинский добавлен вайтлист на целебный порошок и парку.
В пояс инженерный добавлен вайтлист на сварочные очки.
Из категории item лодаута удалена возможность взять 100 крышек.
В категории item лодаута были добавлены следующие пояса - пояс для руды, растений, химии, поясная сумка, верёвочный пояс.
Теперь разведброня СЗБС выдаётся полным комплектом в лодауте, цена скорректирована.
