### PR TITLE
Пассивное восстановление радиационного урона у гулей

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -74,6 +74,13 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Ghoul
+  - type: PassiveDamage
+    damage:
+      types:
+        Heat: -0.07
+        Radiation: -0.05
+      groups:
+        Brute: -0.07
   - type: RadiationReceiver
   - type: RadiationHealing
   - type: MobThresholds
@@ -171,6 +178,13 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: GhoulGlowing
+  - type: PassiveDamage
+    damage:
+      types:
+        Heat: -0.07
+        Radiation: -0.1
+      groups:
+        Brute: -0.07
   - type: RadiationReceiver
   - type: RadiationHealing
   - type: MobThresholds

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -74,6 +74,8 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Ghoul
+  - type: Bloodstream
+    bloodReagent: WastelandBlood
   - type: PassiveDamage
     damage:
       types:
@@ -178,6 +180,8 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: GhoulGlowing
+  - type: Bloodstream
+    bloodReagent: WastelandBlood
   - type: PassiveDamage
     damage:
       types:


### PR DESCRIPTION
## Описание PR

Добавлено пассивное восстановление радиационного урона для двух играбельных рас:

- Обычный гуль (`Ghoul`): 0,05 единицы в секунду — 3 в минуту.
- Светящийся гуль (`GhoulGlowing`): 0,1 единицы в секунду — 6 в минуту.

Обе расы используют радиоактивный реагент крови `WastelandBlood`, который уже применяется у существ пустоши. При заборе шприцем извлекается именно этот реагент.

## Почему / Баланс

Гули постепенно восстанавливаются от накопленного радиационного урона. Светящиеся гули восстанавливаются вдвое быстрее обычных.

Сохранены ограничения базовой пассивной регенерации: только состояние `Alive` и суммарный урон строго ниже 20. При уроне 20 и выше, в критическом состоянии и после смерти эта регенерация не действует. Нахождение рядом с источником радиации не требуется.

## Технические детали

- Изменён только `Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml`.
- В `N14BaseMobGhoul` и `N14BaseMobGhoulGlowing` настроен существующий компонент `PassiveDamage`.
- Сохранено базовое восстановление `Heat: -0.07` и группы `Brute: -0.07`.
- `allowedStates` и `damageCap` наследуются от `BaseMobSpeciesOrganic`.
- Для обоих прототипов расы компонент `Bloodstream` переопределяет стандартный реагент крови на `WastelandBlood`.
- C#, эффекты реагентов, механика шприцев и система лечения от внешнего облучения не изменены.
- Изменение применяется к создаваемым персонажам соответствующих прототипов. Одна лишь смена поля расы уже существующего персонажа не добавляет компонентную настройку.

## Требования

- [ ] Добавлены медиафайлы для демонстрации изменений в игре.

## Критические изменения

Настройка применяется к создаваемым персонажам соответствующих прототипов. Простая смена поля расы у существующего персонажа не добавляет эти настройки компонентов.

**Список изменений**

:cl: akino-tech
- add: Обычные гули восстанавливают 0,05 радиационного урона в секунду, светящиеся — 0,1. Восстановление работает в живом состоянии при суммарном уроне ниже 20.
- add: Обычные и светящиеся гули теперь имеют радиоактивную кровь пустоши.
