### PR TITLE
Племенная одежда в инвентаре выживших

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
@@ -62,56 +62,58 @@
 - type: loadout
   id: N14ClothingOuterBandito
   category: Outer
-  cost: 1
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: &tribalWastelanderJobs
+        - TribalElder
+        - TribalHealer
+        - TribalFarmer
+        - Tribal
+        - Wastelander
+        - Survivor
   items:
     - N14ClothingOuterBandito
 
 - type: loadout
   id: N14ClothingOuterforager
   category: Outer
-  cost: 1
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingOuterforager
 
 - type: loadout
   id: N14ClothingOuterheadtaker
   category: Outer
-  cost: 1
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingOuterheadtaker
 
 - type: loadout
   id: N14ClothingOuterhunter
   category: Outer
-  cost: 1
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingOuterhunter
 
@@ -132,14 +134,13 @@
 - type: loadout
   id: N14ClothingOutershaman
   category: Outer
-  cost: 1
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingOutershaman
 
@@ -194,9 +195,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalHeadWraps
 
@@ -208,9 +208,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalHood
 
@@ -222,9 +221,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalShamanHat
 
@@ -236,9 +234,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalShemagh
 
@@ -250,9 +247,8 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalHunterHood
 
@@ -329,13 +325,12 @@
 - type: loadout
   id: N14ClothingTribalShamanHeadband
   category: Head
-  cost: 1
+  cost: 2
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHead
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Tribe
+    - !type:CharacterJobRequirement
+      jobs: *tribalWastelanderJobs
   items:
     - N14ClothingTribalShamanHeadband

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
@@ -67,6 +67,7 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
+    #forge-start-change
     - !type:CharacterJobRequirement
       jobs: &tribalWastelanderJobs
         - TribalElder
@@ -74,7 +75,7 @@
         - TribalFarmer
         - Tribal
         - Wastelander
-        - Survivor
+    #forge-end-change
   items:
     - N14ClothingOuterBandito
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_tribe.yml
@@ -67,7 +67,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
-    #forge-start-change
     - !type:CharacterJobRequirement
       jobs: &tribalWastelanderJobs
         - TribalElder
@@ -75,7 +74,6 @@
         - TribalFarmer
         - Tribal
         - Wastelander
-    #forge-end-change
   items:
     - N14ClothingOuterBandito
 


### PR DESCRIPTION
## Описание PR

Племенная броня и головные уборы доступны в стартовом инвентаре обитателей пустоши (`Wastelander`). Доступ для племенных ролей сохранён.

## Почему / Баланс

Расширен выбор стартовой одежды. Стоимость пяти комплектов племенной брони повышена с 1 до 3 очков; племенные головные уборы стоят 2 очка.

## Технические детали

В `loadouts_tribe.yml` требование племенного отдела заменено на список профессий: `TribalElder`, `TribalHealer`, `TribalFarmer`, `Tribal` и `Wastelander`. Настройки переиспользуются через YAML-якорь. Изменения только в YAML.

Ранее указанные проверки: YAML-валидатор без ошибок; сервер успешно запущен и принимает подключения; клиент запущен и подключён к локальному серверу.

## Требования

- [ ] Добавлены медиафайлы для демонстрации изменений в игре.

## Критические изменения

Нет.

**Список изменений**

:cl: akino-tech
- add: Племенная броня и головные уборы доступны в стартовом инвентаре обитателей пустоши.
- tweak: Пять комплектов племенной брони стоят 3 очка, племенные головные уборы — 2 очка.
